### PR TITLE
Load collective.monkeypatcher zcml

### DIFF
--- a/src/collective/themesitesetup/configure.zcml
+++ b/src/collective/themesitesetup/configure.zcml
@@ -5,6 +5,7 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="collective.themesitesetup">
 
+  <include package="collective.monkeypatcher" />
   <include package="plone.resource" />
   <include package="plone.app.controlpanel" />
   <include package="plone.app.theming" />


### PR DESCRIPTION
Load collective.monkeypatcher to prevent ConfigurationError.

When `collective.themesitesetup` is added as a package dependency, and `collective.monkeypatcher` is not loaded, then the following error occurs:

```
ZopeXMLConfigurationError: File "/Volumes/Work/Configurations/buildout/shared-eggs/collective.themesitesetup-1.4.1-py2.7.egg/collective/themesitesetup/configure.zcml", line 33.2
    ConfigurationError: ('Unknown directive', u'http://namespaces.plone.org/monkey', u'patch')
```